### PR TITLE
Update default-fstab.yaml

### DIFF
--- a/default-fstab.yaml
+++ b/default-fstab.yaml
@@ -1,5 +1,7 @@
 mountpoints:
-  /: {YOUR_MOUNTPOINT_URL}
+  /:
+    url: https://content.da.live/{org}/{site}/
+    type: markup
 
 folders:
   /products/: /products/default


### PR DESCRIPTION
Update default-fstab.yaml to use da.live environment for mountpoint.

Fix #<USF-2267-starter-content>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
